### PR TITLE
add autolayout constraints for ChatView

### DIFF
--- a/flixnchill/Base.lproj/Main.storyboard
+++ b/flixnchill/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--CardsViewController-->
@@ -9,16 +9,16 @@
             <objects>
                 <viewController storyboardIdentifier="CardsViewController" title="CardsViewController" id="BYZ-38-t0r" customClass="CardsViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="otO-8m-Fuy"/>
-                        <viewControllerLayoutGuide type="bottom" id="04d-yi-IO7"/>
+                        <viewControllerLayoutGuide type="top" id="vg0-tr-2uu"/>
+                        <viewControllerLayoutGuide type="bottom" id="qvS-zT-JaF"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <visualEffectView hidden="YES" opaque="NO" alpha="0.69999999999999996" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AQO-Mh-LPY">
+                            <visualEffectView hidden="YES" opaque="NO" alpha="0.69999999999999996" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AQO-Mh-LPY">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="WMJ-Uk-LyM">
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" id="WMJ-Uk-LyM">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <animations/>
@@ -93,12 +93,6 @@
                         </subviews>
                         <animations/>
                         <color key="backgroundColor" red="0.6470588235294118" green="0.0" blue="0.074509803921568626" alpha="1" colorSpace="calibratedRGB"/>
-                        <constraints>
-                            <constraint firstItem="AQO-Mh-LPY" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="Ef6-Bo-ufd"/>
-                            <constraint firstItem="AQO-Mh-LPY" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="OUs-bp-48x"/>
-                            <constraint firstAttribute="bottom" secondItem="AQO-Mh-LPY" secondAttribute="bottom" id="kaI-zv-WkZ"/>
-                            <constraint firstAttribute="trailing" secondItem="AQO-Mh-LPY" secondAttribute="trailing" id="qeY-IQ-xoO"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="jnp-3f-iLG"/>
                     <connections>
@@ -157,8 +151,8 @@
             <objects>
                 <viewController storyboardIdentifier="LoginViewController" title="LoginViewController" id="XPe-5s-hUn" customClass="LoginViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="BGb-Lv-fq0"/>
-                        <viewControllerLayoutGuide type="bottom" id="OfD-Lc-8hv"/>
+                        <viewControllerLayoutGuide type="top" id="FoT-B4-MvW"/>
+                        <viewControllerLayoutGuide type="bottom" id="Ume-OK-tVF"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kif-GS-X8f">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
@@ -199,8 +193,8 @@
             <objects>
                 <viewController id="q2W-bi-XA8" customClass="ProfileViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="CbY-Nh-Tlz"/>
-                        <viewControllerLayoutGuide type="bottom" id="Unk-UK-iVl"/>
+                        <viewControllerLayoutGuide type="top" id="f8E-dc-8tS"/>
+                        <viewControllerLayoutGuide type="bottom" id="EcA-B0-zaU"/>
                     </layoutGuides>
                     <view key="view" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="lh8-IJ-f7C">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
@@ -287,8 +281,8 @@
             <objects>
                 <viewController id="pPO-en-aF9" customClass="ChatsViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="bym-TY-Nyu"/>
-                        <viewControllerLayoutGuide type="bottom" id="KzK-XB-Eqa"/>
+                        <viewControllerLayoutGuide type="top" id="ANy-bi-unM"/>
+                        <viewControllerLayoutGuide type="bottom" id="Fft-CN-USB"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="GBM-E5-WGc">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
@@ -303,7 +297,7 @@
                                         <rect key="frame" x="0.0" y="28" width="320" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="PDf-kE-aFS" id="wO4-mt-bFe">
-                                            <rect key="frame" x="0.0" y="0.0" width="287" height="65.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="287" height="65"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Jessica" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M8I-n9-N1K">
@@ -372,60 +366,76 @@
             <objects>
                 <viewController id="1Ig-kk-dB9" customClass="ChatViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="Zxz-3q-yqy"/>
-                        <viewControllerLayoutGuide type="bottom" id="KlZ-ZB-ifW"/>
+                        <viewControllerLayoutGuide type="top" id="asG-fq-rgY"/>
+                        <viewControllerLayoutGuide type="bottom" id="v7A-90-okG"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="2h3-4N-SJv">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="back" id="0dx-x9-GQr">
-                                <rect key="frame" x="5" y="20" width="20" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="back" translatesAutoresizingMaskIntoConstraints="NO" id="0dx-x9-GQr">
+                                <rect key="frame" x="8" y="20" width="20" height="20"/>
                                 <animations/>
                                 <gestureRecognizers/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="7pu-Zp-KKZ"/>
+                                    <constraint firstAttribute="width" constant="20" id="yQ9-0Z-eOt"/>
+                                </constraints>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="A4R-FL-DwL" appends="YES" id="LXZ-bF-767"/>
                                 </connections>
                             </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" id="neX-Wu-YSz">
-                                <rect key="frame" x="5" y="498" width="266" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="neX-Wu-YSz">
+                                <rect key="frame" x="5" y="501" width="266" height="30"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="9IJ-4x-4lD">
-                                <rect key="frame" x="278" y="498" width="36" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9IJ-4x-4lD">
+                                <rect key="frame" x="279" y="501" width="36" height="30"/>
                                 <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="36" id="0h5-mT-4bA"/>
+                                </constraints>
                                 <state key="normal" title="Send"/>
                                 <connections>
                                     <action selector="sendButtonTapped:" destination="1Ig-kk-dB9" eventType="touchUpInside" id="EG9-dt-Zlh"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.80000001192092896" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CHAT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="K06-s7-pLX">
-                                <rect key="frame" x="120" y="20" width="100" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.80000001192092896" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CHAT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K06-s7-pLX">
+                                <rect key="frame" x="138" y="20" width="45" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" id="r0n-Wl-5pn">
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r0n-Wl-5pn">
                                 <rect key="frame" x="0.0" y="52" width="320" height="1"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <animations/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="ay4-Nl-N0V">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ay4-Nl-N0V">
                                 <rect key="frame" x="0.0" y="52" width="320" height="444"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </tableView>
                         </subviews>
                         <animations/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="ay4-Nl-N0V" firstAttribute="leading" secondItem="2h3-4N-SJv" secondAttribute="leading" id="4Dq-8l-Way"/>
+                            <constraint firstItem="neX-Wu-YSz" firstAttribute="top" secondItem="ay4-Nl-N0V" secondAttribute="bottom" constant="5" id="4NR-yc-WNK"/>
+                            <constraint firstItem="neX-Wu-YSz" firstAttribute="leading" secondItem="2h3-4N-SJv" secondAttribute="leading" constant="5" id="7c1-rr-Xyb"/>
+                            <constraint firstAttribute="trailing" secondItem="ay4-Nl-N0V" secondAttribute="trailing" id="PMg-ao-aRc"/>
+                            <constraint firstItem="K06-s7-pLX" firstAttribute="centerY" secondItem="0dx-x9-GQr" secondAttribute="centerY" id="X2X-cz-WcI"/>
+                            <constraint firstAttribute="trailing" secondItem="neX-Wu-YSz" secondAttribute="trailing" constant="49" id="Yqo-5K-fvB"/>
+                            <constraint firstItem="K06-s7-pLX" firstAttribute="centerX" secondItem="2h3-4N-SJv" secondAttribute="centerX" id="cY2-3C-dj3"/>
+                            <constraint firstItem="9IJ-4x-4lD" firstAttribute="leading" secondItem="neX-Wu-YSz" secondAttribute="trailing" constant="8" id="e8Q-ZR-zLO"/>
+                            <constraint firstItem="ay4-Nl-N0V" firstAttribute="top" secondItem="K06-s7-pLX" secondAttribute="bottom" constant="11" id="hWb-6S-kdi"/>
+                            <constraint firstItem="0dx-x9-GQr" firstAttribute="leading" secondItem="2h3-4N-SJv" secondAttribute="leading" constant="8" id="hwy-Fi-HnV"/>
+                            <constraint firstItem="9IJ-4x-4lD" firstAttribute="centerY" secondItem="neX-Wu-YSz" secondAttribute="centerY" id="qZD-qZ-GPR"/>
+                            <constraint firstAttribute="bottom" secondItem="ay4-Nl-N0V" secondAttribute="bottom" constant="72" id="ujg-c0-eNb"/>
+                            <constraint firstItem="0dx-x9-GQr" firstAttribute="top" secondItem="asG-fq-rgY" secondAttribute="bottom" id="xSN-BH-7vD"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="chatTextField" destination="neX-Wu-YSz" id="woI-Lw-Ken"/>
@@ -448,8 +458,8 @@
             <objects>
                 <viewController id="j9i-iR-JBu" customClass="SettingsViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="Rg5-K6-Cas"/>
-                        <viewControllerLayoutGuide type="bottom" id="840-gw-ao3"/>
+                        <viewControllerLayoutGuide type="top" id="YbE-WX-RyQ"/>
+                        <viewControllerLayoutGuide type="bottom" id="Tkd-Db-NpV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="l5k-lt-WzY">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
@@ -475,6 +485,7 @@
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0z0-AS-v9V">
                                 <rect key="frame" x="145" y="493" width="30" height="30"/>
+                                <animations/>
                             </button>
                             <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="arrowleftwhiteonred" translatesAutoresizingMaskIntoConstraints="NO" id="2wT-de-2Ur">
                                 <rect key="frame" x="10" y="24" width="20" height="24"/>


### PR DESCRIPTION
Previously, The ChatViewController appeared broken because autolayout was enabled (perhaps during conflict resolution) and no constraints were set . This adds constraints and fixes the view
